### PR TITLE
Use the proper function to write signed integers

### DIFF
--- a/lib/write-token.js
+++ b/lib/write-token.js
@@ -64,7 +64,7 @@ function init_optimized() {
   token[0xd0] = write1(0xd0);
   token[0xd1] = write2(0xd1);
   token[0xd2] = write4(0xd2);
-  token[0xd3] = writeN(0xd3, 8, BufferLite.writeUint64BE);
+  token[0xd3] = writeN(0xd3, 8, BufferLite.writeInt64BE);
 
   // str 8 -- 0xd9
   // str 16 -- 0xda
@@ -120,7 +120,7 @@ function init_compatible() {
   token[0xd0] = writeN(0xd0, 1, Buffer.prototype.writeInt8);
   token[0xd1] = writeN(0xd1, 2, Buffer.prototype.writeInt16BE);
   token[0xd2] = writeN(0xd2, 4, Buffer.prototype.writeInt32BE);
-  token[0xd3] = writeN(0xd3, 8, BufferLite.writeUint64BE);
+  token[0xd3] = writeN(0xd3, 8, BufferLite.writeInt64BE);
 
   // str 8 -- 0xd9
   // str 16 -- 0xda


### PR DESCRIPTION
For negative 64-bit numbers, writeInt64BE should be used, yes? I know the code isn't currently being used anywhere but I ran into this while attempting to manually serialize Number.MIN_SAFE_INTEGER as an integer.
